### PR TITLE
Fix ProgramEditPage params type

### DIFF
--- a/frontend/src/app/dashboard/coach/programs/[programId]/page.tsx
+++ b/frontend/src/app/dashboard/coach/programs/[programId]/page.tsx
@@ -1,11 +1,11 @@
 import ProgramGeneralForm from "@/components/program/edit/ProgramGeneralForm";
 
-export default async function ProgramEditPage({ 
-  params 
-}: { 
-  params: Promise<{ programId: string }> 
+export default async function ProgramEditPage({
+  params,
+}: {
+  params: { programId: string };
 }) {
-  const { programId } = await params;
+  const { programId } = params;
 
   const res = await fetch(`https://kulvar-qb7t.onrender.com/programs/${programId}`, {
     headers: {


### PR DESCRIPTION
## Summary
- fix type for `params` in ProgramEditPage

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876339f10108322aafc204f49f0891a